### PR TITLE
chore: bump ospo-reusable-workflows release.yaml to v1.0.0

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -8,6 +8,9 @@ template: |
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
 
 categories:
+  - title: "💥 Breaking Changes"
+    labels:
+      - "breaking"
   - title: "🚀 Features"
     labels:
       - "feature"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write       # only needed if creating attestations
       attestations: write   # only needed if creating attestations
       discussions: write    # only needed if creating discussions
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@6a18300646271cef1dbc49a83523acf5d1d94b57
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true
       goreleaser-config-path: .goreleaser.yaml


### PR DESCRIPTION
## What

Pin the reusable release workflow to v1.0.0 (SHA 592067a69a43d2285f933753d89a7c9d51b96530), use the reusable workflow's built-in GoReleaser support, and add a Breaking Changes category to release-drafter.

## Why

v1.0.0 of ospo-reusable-workflows broadens the release trigger to include breaking, feature, vuln, and release labels and folds GoReleaser, container image build, attestation, and discussion creation into the reusable workflow itself. This repo exists to exercise the reusable workflow end-to-end so the pin should stay current with the latest release.

## Notes

- The `.goreleaser.yaml` already sets `release.disable: true` which the v1.0 reusable workflow validates.
- The outer label-filter `if:` block is not present in this workflow, so nothing needed to be removed.
- Trigger remains `pull_request_target` so the workflow can push tags via `GITHUB_TOKEN`.

## Testing

- [ ] Workflow syntax parses on push
- [ ] On merge of a labeled PR to main, the reusable workflow runs end-to-end (release-drafter, GoReleaser build, attestation, discussion)
- [ ] Breaking Changes category renders correctly in the drafted release notes when a `breaking` labeled PR is included